### PR TITLE
Reduce word count in PR template

### DIFF
--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -1,11 +1,11 @@
 # Description
 
-Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
+Include a summary of the change and issue fixed. Include relevant motivation and context. List any required dependencies for this change.
 
 
 # How Has This Been Tested?
 
-Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
+Describe the tests that you ran to verify your changes. Provide instructions so we can reproduce your results. List any relevant testing configuration details.
 
 - [ ] Test A
 - [ ] Test B
@@ -13,7 +13,7 @@ Please describe the tests that you ran to verify your changes. Provide instructi
 
 # Monitoring/KPIs
 
-Does this PR introduce any additional KPI metrics that should be measured to ensure the project/deployment is successful?
+List KPIs that should be measured to ensure the project/deployment is successful.
 
 - [ ] KPI 1
 - [ ] KPI 2
@@ -21,27 +21,26 @@ Does this PR introduce any additional KPI metrics that should be measured to ens
 
 # Documentation
 
-- [ ] This change requires a documentation update
-  - [ ] Documentation for the change has been written and is available here: <link>
-  - [ ] Documentation for the change will be written at a later date
+- [ ] Requires documentation update
+  - [ ] Documentation written and available [here](link)
+  - [ ] Documentation can be written later
   
 
 # Contributor Checklist:
 
-- [ ] My code follows the style guidelines of this project
-- [ ] I have performed a self-review of my own code
-- [ ] I have commented my code, particularly in hard-to-understand areas
-- [ ] I have added tests that prove my fix is effective or that my feature works
-- [ ] New and existing unit tests pass locally with my changes
-- [ ] A monitoring plan is in place to ensure any issues with the release will be promptly detected
-- [ ] Any dependent changes have been merged and published in downstream modules
+- [ ] Code has been thoroughly reviewed
+- [ ] Code follows style guidelines
+- [ ] Code contains comments throughout, esp. in hard-to-understand areas
+- [ ] Unit tests pass locally, show commits successfully fix bug and/or implement feature
+- [ ] Monitoring plan is in place to detect issues with release
+- [ ] Dependent changes are published in downstream modules
 
 
 # Manager/Reviewer Checklist:
 
-- [ ] I have performed a review of the modified code
+- [ ] I have reviewed the modified code
 - [ ] I have evaluated the potential for this change to affect other systems
-- [ ] I have thoroughly reviewed and/or re-run the tests outlined by the contributor
-- [ ] I have reviewed any new documentation necessitated by this PR
-- [ ] I have reviewed the monitoring plan and am confident that any issue with the rollout will be detected
+- [ ] I have reviewed and/or re-run the tests outlined by the contributor
+- [ ] I have reviewed any new documentation
+- [ ] I have reviewed the monitoring plan and am confident that issues will be detected
 

--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -31,7 +31,8 @@ List KPIs that should be measured to ensure the project/deployment is successful
 - [ ] Code has been thoroughly reviewed
 - [ ] Code follows style guidelines
 - [ ] Code contains comments throughout, esp. in hard-to-understand areas
-- [ ] Unit tests pass locally, show commits successfully fix bug and/or implement feature
+- [ ] I have added tests that prove my fix is effective or that my feature works
+- [ ] New and existing unit tests pass locally with my changes
 - [ ] Monitoring plan is in place to detect issues with release
 - [ ] Dependent changes are published in downstream modules
 

--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -3,7 +3,7 @@
 Include a summary of the change and issue fixed. Include relevant motivation and context. List any required dependencies for this change.
 
 
-# How Has This Been Tested?
+# Testing
 
 Describe the tests that you ran to verify your changes. Provide instructions so we can reproduce your results. List any relevant testing configuration details.
 

--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -33,7 +33,7 @@ List KPIs that should be measured to ensure the project/deployment is successful
 - [ ] Code contains comments throughout, esp. in hard-to-understand areas
 - [ ] I have added tests that prove my fix is effective or that my feature works
 - [ ] New and existing unit tests pass locally with my changes
-- [ ] Monitoring plan is in place to detect issues with release
+- [ ] A monitoring plan is in place to detect issues with the release
 - [ ] Dependent changes are published in downstream modules
 
 
@@ -43,5 +43,5 @@ List KPIs that should be measured to ensure the project/deployment is successful
 - [ ] I have evaluated the potential for this change to affect other systems
 - [ ] I have reviewed and/or re-run the tests outlined by the contributor
 - [ ] I have reviewed any new documentation
-- [ ] I have reviewed the monitoring plan and am confident that issues will be detected
+- [ ] I have reviewed the monitoring plan and am confident that any issues will be detected
 


### PR DESCRIPTION
# Description

Include a summary of the change and which issue is fixed. Include relevant motivation and context. List any dependencies that are required for this change.

In this PR, I reduce the word count of the PR template. By distilling this template down to just its essential aspects, adoption by the engineering team will improve.

# Testing

Describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. List any relevant details for your testing configuration.

- [x] I read through my changes thrice, (configuration: eyeglasses, surface book)


# Monitoring/KPIs

List KPI metrics that should be measured to ensure the project/deployment is successful.

- [x] word count: 267->190 words


# Documentation

- [x] Requires documentation update
  - [x] Documentation written and available [here](https://github.com/thetake/.github/blob/master/pull_request_template.md)
  - [ ] Documentation to be written later
  

# Contributor Checklist:

- [x] Code has been thoroughly reviewed
- [x] Code follows style guidelines
- [x] Code contains comments throughout, esp. in hard-to-understand areas
- [x] Unit tests pass locally, show commits successfully fix bug and/or implement feature
- [x] Monitoring plan is in place to detect issues with release
- [x] Dependent changes are published in downstream modules


# Manager/Reviewer Checklist:

- [ ] I have reviewed the modified code
- [ ] I have evaluated the potential for this change to affect other systems
- [ ] I have reviewed and/or re-run the tests outlined by the contributor
- [ ] I have reviewed any new documentation
- [ ] I have reviewed the monitoring plan and am confident that issues will be detected